### PR TITLE
runtimes: include EOLed ones as well

### DIFF
--- a/master/buildbot/flathub_master.py
+++ b/master/buildbot/flathub_master.py
@@ -1283,7 +1283,7 @@ def create_periodic_purge_factory():
     return periodic_purge_factory
 
 def get_runtimes(remote):
-    runtimes_command = "flatpak remote-ls --user --runtime --columns=application,branch,arch --arch='*' {}"
+    runtimes_command = "flatpak remote-ls --user --all --runtime --columns=application,branch,arch --arch='*' {}"
     runtimes_run = subprocess.Popen(runtimes_command.format(remote), shell=True, stdout=subprocess.PIPE, universal_newlines=True)
     output, _ = runtimes_run.communicate()
     runtimes = {}


### PR DESCRIPTION
flatpak remote-ls doesn't include EOL'ed runtimes by default unless --all flag is passed
this is needed to allow "old" applications to still update for whatever reason


cc @barthalion @ptomato