### PR TITLE
Allow EOL'ed SDKs

### DIFF
--- a/master/buildbot/flathub_master.py
+++ b/master/buildbot/flathub_master.py
@@ -1282,6 +1282,9 @@ def create_periodic_purge_factory():
     ])
     return periodic_purge_factory
 
+
+# Map available architectures of refs possible to use as SDKs. This is needed
+# to dynamically detect what architectures are available to build against.
 def get_sdks(remote):
     runtimes_command = "flatpak remote-ls --user --runtime --columns=ref --arch='*' --all {}"
     runtimes_run = subprocess.Popen(runtimes_command.format(remote), shell=True, stdout=subprocess.PIPE, universal_newlines=True)


### PR DESCRIPTION
The change to dynamically look up available architectures by using
"flatpak remote-ls" caused EOL'ed runtimes/SDKs to disappear,
rendering some applications impossible to build without runtime
bump.

Pass "--all" to "flatpak remote-ls" and filter refs to return only
those matching *.Sdk or *.Platform.

## Remove this paragraph

If you don't remove this paragraph from the pull request description, this means you didn't read our contributor documentation, and your patch will need more back and forth before it can be accepted!

Please have a look at our developer documentation before submitting your Pull Request.

http://docs.buildbot.net/latest/developer/quickstart.html

And especially:
http://docs.buildbot.net/latest/developer/pull-request.html


## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
