### PR TITLE
Fix bug in flathub-merge-sources.sh.

### DIFF
--- a/master/buildbot/flathub_master.py
+++ b/master/buildbot/flathub_master.py
@@ -444,7 +444,7 @@ class RepoRequestStep(steps.BuildStep):
                 return
             session.close()
 
-            if response.status_code == requests.codes.service_unavailable:
+            if response.status_code in (408, 503):
                 retries = retries + 1
                 if retries < 5:
                     log.addStderr('Got 503, retrying in 10 sec...')

--- a/master/buildbot/scripts/flathub-merge-sources.sh
+++ b/master/buildbot/scripts/flathub-merge-sources.sh
@@ -12,7 +12,7 @@ fi
 
 for vcs in git bzr svn; do
     mkdir -p $SOURCEDIR/$vcs
-    for repo in .flatpak-builder/git/*; do
+    for repo in .flatpak-builder/$vcs/*; do
         mv -nvT $repo $SOURCEDIR/$vcs/`basename $repo`
     done
 done


### PR DESCRIPTION
There was a small typo in the merge-source script, that would actually only merge git repos, and also merge them where they should not be (like under `bzr/`).
