### PR TITLE
Apply `git submodule sync` recursively 

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -467,7 +467,7 @@ class Git(Source, GitStepMixin):
     def _syncSubmodule(self, _=None):
         rc = RC_SUCCESS
         if self.submodules:
-            rc = yield self._dovccmd(['submodule', 'sync'])
+            rc = yield self._dovccmd(['submodule', 'sync', '--recursive'])
         return rc
 
     @defer.inlineCallbacks


### PR DESCRIPTION

This should fix build errors where a maintainer uploaded a second level submodule first with a git/ssh remote